### PR TITLE
UC2: associazione Nota-Cartella (sposta e filtro) + fix test

### DIFF
--- a/src/main/java/it/unibo/progettonote/Cartella.java
+++ b/src/main/java/it/unibo/progettonote/Cartella.java
@@ -1,0 +1,56 @@
+package it.unibo.progettonote;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+public class Cartella implements Serializable {
+
+    private final String id = UUID.randomUUID().toString();
+    private String nome;
+    private final String proprietario; // username dell’utente
+
+    public Cartella(String nome, String proprietario) {
+        if (nome == null || nome.trim().isEmpty()) {
+            throw new IllegalArgumentException("Il nome della cartella non può essere vuoto");
+        }
+        if (proprietario == null || proprietario.trim().isEmpty()) {
+            throw new IllegalArgumentException("Il proprietario non può essere nullo");
+        }
+
+        this.nome = nome;
+        this.proprietario = proprietario;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        if (nome == null || nome.trim().isEmpty()) {
+            throw new IllegalArgumentException("Il nome della cartella non può essere vuoto");
+        }
+        this.nome = nome;
+    }
+
+    public String getProprietario() {
+        return proprietario;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Cartella)) return false;
+        Cartella cartella = (Cartella) o;
+        return Objects.equals(id, cartella.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/it/unibo/progettonote/DatabaseCartelle.java
+++ b/src/main/java/it/unibo/progettonote/DatabaseCartelle.java
@@ -1,0 +1,33 @@
+package it.unibo.progettonote;
+
+import org.mapdb.Serializer;
+
+import java.util.concurrent.ConcurrentNavigableMap;
+
+public class DatabaseCartelle {
+
+    private static ConcurrentNavigableMap<String, Cartella> cartelleRepo;
+
+    public static void enableTestMode() {
+        DatabaseCore.enableTestMode();
+        cartelleRepo = null;
+    }
+
+    public static void disableTestMode() {
+        DatabaseCore.disableTestMode();
+        cartelleRepo = null;
+    }
+
+    public static ConcurrentNavigableMap<String, Cartella> getCartelleRepo() {
+        if (cartelleRepo == null) {
+            cartelleRepo = DatabaseCore.getDB()
+                    .treeMap("cartelle", Serializer.STRING, Serializer.JAVA)
+                    .createOrOpen();
+        }
+        return cartelleRepo;
+    }
+
+    public static void close() {
+        cartelleRepo = null; // NON chiudere DatabaseCore qui
+    }
+}

--- a/src/main/java/it/unibo/progettonote/DatabaseCore.java
+++ b/src/main/java/it/unibo/progettonote/DatabaseCore.java
@@ -1,0 +1,42 @@
+package it.unibo.progettonote;
+
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+
+public class DatabaseCore {
+
+    private static DB db;
+    private static boolean testMode = false;
+
+    public static void enableTestMode() {
+        testMode = true;
+        close();
+    }
+
+    public static void disableTestMode() {
+        testMode = false;
+        close();
+    }
+
+    public static DB getDB() {
+        if (db == null || db.isClosed()) {
+            if (testMode) {
+                db = DBMaker.memoryDB().transactionEnable().make();
+            } else {
+                db = DBMaker.fileDB("progetto_sweng.db").transactionEnable().make();
+            }
+        }
+        return db;
+    }
+
+    public static void commit() {
+        getDB().commit();
+    }
+
+    public static void close() {
+        if (db != null && !db.isClosed()) {
+            db.close();
+        }
+        db = null;
+    }
+}

--- a/src/main/java/it/unibo/progettonote/DatabaseNote.java
+++ b/src/main/java/it/unibo/progettonote/DatabaseNote.java
@@ -1,0 +1,23 @@
+package it.unibo.progettonote;
+
+import org.mapdb.Serializer;
+
+import java.util.concurrent.ConcurrentNavigableMap;
+
+public class DatabaseNote {
+
+    private static ConcurrentNavigableMap<String, Nota> noteRepo;
+
+    public static ConcurrentNavigableMap<String, Nota> getNoteRepo() {
+        if (noteRepo == null) {
+            noteRepo = DatabaseCore.getDB()
+                    .treeMap("notes", Serializer.STRING, Serializer.JAVA)
+                    .createOrOpen();
+        }
+        return noteRepo;
+    }
+
+    public static void close() {
+        noteRepo = null; // NON chiudere DatabaseCore qui
+    }
+}

--- a/src/main/java/it/unibo/progettonote/Nota.java
+++ b/src/main/java/it/unibo/progettonote/Nota.java
@@ -7,13 +7,14 @@ import java.util.List;
 
 public class Nota implements Serializable {
     private static final long serialVersionUID = 1L;
+
     private String id;
     private String titolo;
     private String contenuto;
     private Date dataCreazione;
     private Date dataUltimaModifica;
     private String proprietario;
-    private String idCartella;
+    private String idCartella; // può essere null
     private List<VersioneNota> versioni = new ArrayList<>();
 
     public Nota() {}
@@ -26,12 +27,27 @@ public class Nota implements Serializable {
         this.dataUltimaModifica = new Date();
     }
 
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getTitolo() { return titolo; }
+    public void setTitolo(String titolo) { this.titolo = titolo; }
+
     public String getContenuto() { return contenuto; }
     public void setContenuto(String contenuto) { this.contenuto = contenuto; }
-    public void setTitolo(String titolo) { this.titolo = titolo; }
-    public void setProprietario(String proprietario) { this.proprietario = proprietario; }
-    public void setIdCartella(String idCartella) { this.idCartella = idCartella; }
+
+    public Date getDataCreazione() { return dataCreazione; }
     public void setDataCreazione(Date date) { this.dataCreazione = date; }
+
+    public Date getDataUltimaModifica() { return dataUltimaModifica; }
     public void setDataUltimaModifica(Date date) { this.dataUltimaModifica = date; }
+
+    public String getProprietario() { return proprietario; }
+    public void setProprietario(String proprietario) { this.proprietario = proprietario; }
+
+    public String getIdCartella() { return idCartella; }
+    public void setIdCartella(String idCartella) { this.idCartella = idCartella; }
+
     public List<VersioneNota> getVersioni() { return versioni; }
+    public void setVersioni(List<VersioneNota> versioni) { this.versioni = versioni; }
 }

--- a/src/main/java/it/unibo/progettonote/NotaCartellaService.java
+++ b/src/main/java/it/unibo/progettonote/NotaCartellaService.java
@@ -1,0 +1,53 @@
+package it.unibo.progettonote;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentNavigableMap;
+
+public class NotaCartellaService {
+
+    private final ConcurrentNavigableMap<String, Nota> noteRepo;
+    private final ConcurrentNavigableMap<String, Cartella> cartelleRepo;
+
+    public NotaCartellaService() {
+        this.noteRepo = DatabaseNote.getNoteRepo();
+        this.cartelleRepo = DatabaseCartelle.getCartelleRepo();
+    }
+
+    public void spostaNotaInCartella(String notaId, String cartellaId, String proprietario) {
+        if (notaId == null || notaId.isBlank()) throw new IllegalArgumentException("notaId non valido");
+        if (cartellaId == null || cartellaId.isBlank()) throw new IllegalArgumentException("cartellaId non valido");
+        if (proprietario == null || proprietario.isBlank()) throw new IllegalArgumentException("proprietario non valido");
+
+        Cartella cartella = cartelleRepo.get(cartellaId);
+        if (cartella == null) throw new IllegalArgumentException("Cartella inesistente");
+        if (!cartella.getProprietario().equals(proprietario)) throw new IllegalArgumentException("Cartella non appartenente all'utente");
+
+        Nota nota = noteRepo.get(notaId);
+        if (nota == null) throw new IllegalArgumentException("Nota inesistente");
+        if (nota.getProprietario() == null || !nota.getProprietario().equals(proprietario)) {
+            throw new IllegalArgumentException("Nota non appartenente all'utente");
+        }
+
+        nota.setIdCartella(cartellaId);
+        noteRepo.put(notaId, nota);
+        DatabaseCore.commit();
+    }
+
+    public List<Nota> listaNotePerCartella(String cartellaId, String proprietario) {
+        if (cartellaId == null || cartellaId.isBlank()) throw new IllegalArgumentException("cartellaId non valido");
+        if (proprietario == null || proprietario.isBlank()) throw new IllegalArgumentException("proprietario non valido");
+
+        Cartella cartella = cartelleRepo.get(cartellaId);
+        if (cartella == null) throw new IllegalArgumentException("Cartella inesistente");
+        if (!cartella.getProprietario().equals(proprietario)) throw new IllegalArgumentException("Cartella non appartenente all'utente");
+
+        List<Nota> risultato = new ArrayList<>();
+        for (Nota n : noteRepo.values()) {
+            if (proprietario.equals(n.getProprietario()) && cartellaId.equals(n.getIdCartella())) {
+                risultato.add(n);
+            }
+        }
+        return risultato;
+    }
+}

--- a/src/test/java/it/unibo/progettonote/NotaCartellaServiceTest.java
+++ b/src/test/java/it/unibo/progettonote/NotaCartellaServiceTest.java
@@ -1,0 +1,93 @@
+package it.unibo.progettonote;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class NotaCartellaServiceTest {
+
+    @Before
+    public void setup() {
+        // DB in-memory fresh
+        DatabaseCore.enableTestMode();
+
+        // reset riferimenti a mappe (così non usi mappe vecchie)
+        DatabaseCartelle.close();
+        DatabaseNote.close();
+
+        // ora prendi mappe nuove e puliscile
+        DatabaseCartelle.getCartelleRepo().clear();
+        DatabaseNote.getNoteRepo().clear();
+        DatabaseCore.commit();
+    }
+
+    @Test
+    public void spostaNotaInCartellaOk() {
+        String user = "mario";
+
+        Cartella c = new Cartella("Lavoro", user);
+        DatabaseCartelle.getCartelleRepo().put(c.getId(), c);
+
+        Nota n = new Nota("Titolo", "Contenuto", user);
+        String notaId = UUID.randomUUID().toString();
+        n.setId(notaId);
+        DatabaseNote.getNoteRepo().put(notaId, n);
+
+        DatabaseCore.commit();
+
+        NotaCartellaService service = new NotaCartellaService();
+        service.spostaNotaInCartella(notaId, c.getId(), user);
+
+        Nota aggiornata = DatabaseNote.getNoteRepo().get(notaId);
+        assertEquals(c.getId(), aggiornata.getIdCartella());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void spostaNotaInCartellaCartellaNonMia() {
+        String user = "mario";
+
+        Cartella c = new Cartella("Segreta", "luigi");
+        DatabaseCartelle.getCartelleRepo().put(c.getId(), c);
+
+        Nota n = new Nota("Titolo", "Contenuto", user);
+        String notaId = UUID.randomUUID().toString();
+        n.setId(notaId);
+        DatabaseNote.getNoteRepo().put(notaId, n);
+
+        DatabaseCore.commit();
+
+        NotaCartellaService service = new NotaCartellaService();
+        service.spostaNotaInCartella(notaId, c.getId(), user);
+    }
+
+    @Test
+    public void listaNotePerCartellaOk() {
+        String user = "mario";
+
+        Cartella c = new Cartella("Lavoro", user);
+        DatabaseCartelle.getCartelleRepo().put(c.getId(), c);
+
+        Nota n1 = new Nota("A", "X", user);
+        n1.setId(UUID.randomUUID().toString());
+        n1.setIdCartella(c.getId());
+
+        Nota n2 = new Nota("B", "Y", user);
+        n2.setId(UUID.randomUUID().toString());
+        n2.setIdCartella(null);
+
+        DatabaseNote.getNoteRepo().put(n1.getId(), n1);
+        DatabaseNote.getNoteRepo().put(n2.getId(), n2);
+
+        DatabaseCore.commit();
+
+        NotaCartellaService service = new NotaCartellaService();
+        List<Nota> res = service.listaNotePerCartella(c.getId(), user);
+
+        assertEquals(1, res.size());
+        assertEquals("A", res.get(0).getTitolo());
+    }
+}

--- a/src/test/java/it/unibo/progettonote/RegistrazioneTest.java
+++ b/src/test/java/it/unibo/progettonote/RegistrazioneTest.java
@@ -1,25 +1,36 @@
 package it.unibo.progettonote;
 
 import org.junit.Test;
+
+import java.util.UUID;
+
 import static org.junit.Assert.*;
 
 public class RegistrazioneTest {
 
     @Test
     public void testRegistrazioneSuccesso() {
-        GestioneUtenti service = new GestioneUtenti();
-        boolean risultato = service.registraNuovoUtente("mario88", "mario@email.it", "pass1234");
-        assertTrue("La registrazione dovrebbe avere successo", risultato);
+        GestioneUtenti gu = new GestioneUtenti();
 
+        String username = "user_" + UUID.randomUUID();
+        String email = "user_" + UUID.randomUUID() + "@email.it";
+
+        boolean ok = gu.registraNuovoUtente(username, email, "password123");
+        assertTrue("La registrazione dovrebbe avere successo", ok);
     }
 
     @Test
-    public void testEmailGiaEsistente() {
-        GestioneUtenti service = new GestioneUtenti();
-        service.registraNuovoUtente("utente1", "test@test.it", "password");
+    public void testRegistrazioneEmailDuplicata() {
+        GestioneUtenti gu = new GestioneUtenti();
 
-        // Tentativo con stessa email
-        boolean risultato = service.registraNuovoUtente("utente2", "test@test.it", "altrapass");
-        assertFalse("Non dovrebbe permettere email duplicate", risultato);
+        String username1 = "user_" + UUID.randomUUID();
+        String email = "dup_" + UUID.randomUUID() + "@email.it";
+
+        assertTrue(gu.registraNuovoUtente(username1, email, "password123"));
+
+        String username2 = "user_" + UUID.randomUUID();
+        boolean ok2 = gu.registraNuovoUtente(username2, email, "password123");
+
+        assertFalse("La registrazione dovrebbe fallire per email duplicata", ok2);
     }
 }


### PR DESCRIPTION
Implementata associazione Nota–Cartella:

- aggiunto supporto idCartella in Nota
- service per spostare nota in cartella
- filtro note per cartella con controllo proprietario
- DB condiviso (DatabaseCore)
- test unitari completi
- fix RegistrazioneTest con dati unici

Closes #25